### PR TITLE
Limit builds to Linux architectures and pin Go version

### DIFF
--- a/.github/workflows/mirror-cri-dockerd.yml
+++ b/.github/workflows/mirror-cri-dockerd.yml
@@ -1,0 +1,99 @@
+name: Mirror cri-dockerd tags
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      UPSTREAM_REPO: https://github.com/Mirantis/cri-dockerd.git
+      ARCHES: |
+        linux/amd64
+        linux/arm64
+        linux/arm
+        linux/ppc64le
+        linux/s390x
+        linux/386
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.9"
+
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream "${UPSTREAM_REPO}" || git remote set-url upstream "${UPSTREAM_REPO}"
+          git fetch upstream --tags --prune
+
+      - name: Mirror new tags to origin
+        run: |
+          set -euo pipefail
+          NEW_TAGS=()
+          while read -r ref; do
+            tag="${ref#refs/tags/}"
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "Tag ${tag} already exists locally."
+              continue
+            fi
+            echo "Discovered new tag ${tag}."
+            git fetch upstream "refs/tags/${tag}:refs/tags/${tag}"
+            git push origin "refs/tags/${tag}:refs/tags/${tag}"
+            NEW_TAGS+=("${tag}")
+          done < <(git ls-remote --tags upstream | awk '{print $2}' | grep -v '\^{}')
+
+          printf "%s\n" "${NEW_TAGS[@]:-}" > /tmp/new_tags
+
+      - name: Build and release new tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -s /tmp/new_tags ]; then
+            echo "No new tags to build."
+            exit 0
+          fi
+
+          while read -r tag; do
+            echo "Processing ${tag}."
+            git checkout "refs/tags/${tag}"
+            go mod download
+            rm -rf artifacts
+            mkdir -p artifacts
+
+            while read -r pair; do
+              GOOS=${pair%%/*}
+              GOARCH=${pair##*/}
+              BIN_NAME="cri-dockerd-${tag}-${GOOS}-${GOARCH}"
+              OUTPUT="artifacts/${BIN_NAME}"
+              EXT=""
+              if [ "${GOOS}" = "windows" ]; then
+                EXT=".exe"
+              fi
+
+              echo "Building ${BIN_NAME}."
+              GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 go build -ldflags "-s -w" -o "${OUTPUT}${EXT}" ./cmd/cri-dockerd
+
+              if [ "${GOOS}" = "windows" ]; then
+                zip -j "${OUTPUT}.zip" "${OUTPUT}${EXT}"
+                rm "${OUTPUT}${EXT}"
+              else
+                tar -C artifacts -czf "${OUTPUT}.tar.gz" "${BIN_NAME}${EXT}"
+                rm "${OUTPUT}${EXT}"
+              fi
+            done <<< "${ARCHES}"
+
+            gh release create "${tag}" --title "${tag}" --notes "Automated mirror of upstream tag ${tag}." --target "refs/tags/${tag}" || gh release view "${tag}" >/dev/null
+            gh release upload "${tag}" artifacts/* --clobber
+          done < /tmp/new_tags
+
+          git checkout -


### PR DESCRIPTION
## Summary
- restrict release builds to Linux architectures only, removing Windows and macOS targets
- pin Go toolchain to version 1.24.9 to match upstream `go.mod`

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3bf581f8832fa7c71a697379b97a)