### PR TITLE
Add workflow to mirror latest upstream tags

### DIFF
--- a/.github/workflows/mirror-latest-tags.yml
+++ b/.github/workflows/mirror-latest-tags.yml
@@ -1,0 +1,101 @@
+name: Mirror latest upstream releases
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.find-tags.outputs.tags }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Find latest tags without releases
+        id: find-tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eo pipefail
+          tags=$(gh api repos/Mirantis/cri-dockerd/tags?per_page=10 | jq -r '.[].name')
+          missing=()
+          for tag in $tags; do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "Release for $tag already exists, skipping"
+            else
+              missing+=("$tag")
+            fi
+          done
+
+          if [ ${#missing[@]} -eq 0 ]; then
+            echo "No missing releases found"
+            echo "tags=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          json=$(printf '%s\n' "${missing[@]}" | jq -R . | jq -s .)
+          echo "tags=$json" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: discover
+    if: needs.discover.outputs.tags != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJson(needs.discover.outputs.tags) }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout workflow repo
+        uses: actions/checkout@v4
+      - name: Checkout upstream source
+        uses: actions/checkout@v4
+        with:
+          repository: Mirantis/cri-dockerd
+          ref: ${{ matrix.tag }}
+          path: upstream
+          fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: upstream/go.mod
+      - name: Build binaries
+        working-directory: upstream
+        run: |
+          set -eux -o pipefail
+          version="${{ matrix.tag }}"
+          commit=$(git rev-parse HEAD)
+          short_commit=${commit:0:7}
+          archs=("amd64" "arm64" "arm" "s390x" "ppc64le")
+
+          mkdir -p build
+          for arch in "${archs[@]}"; do
+            echo "Building linux/$arch"
+            env GOOS=linux GOARCH=$arch CGO_ENABLED=0 go build \
+              -ldflags "-X github.com/Mirantis/cri-dockerd/version.Version=${version} -X github.com/Mirantis/cri-dockerd/version.GitCommit=${short_commit}" \
+              -o "build/cri-dockerd-${version}.${arch}"
+          done
+
+          cp packaging/systemd/cri-docker.service build/
+          cp packaging/systemd/cri-docker.socket build/
+
+      - name: Create release and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ matrix.tag }}"
+          notes="Mirror of upstream release ${tag}"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists, reusing"
+          else
+            gh release create "$tag" --title "$tag" --notes "$notes"
+          fi
+
+          gh release upload "$tag" upstream/build/*


### PR DESCRIPTION
## Summary
- add scheduled workflow to find latest upstream cri-dockerd tags without releases
- build linux binaries for multiple architectures and copy systemd units for each missing tag
- create or reuse releases in this mirror and upload built assets

## Testing
- not run (workflow automation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692213893f50832f8eaeefbd7cc1f3cb)